### PR TITLE
Fix build:ts on Twilio client after TypeScript

### DIFF
--- a/src/default/helpers/index.js
+++ b/src/default/helpers/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  eachWithPublic: function(context, options) {
+  eachWithPublic: function(context = [], options) {
     return context.filter(ctx =>
       ctx.children.filter(child => child.cssClasses.indexOf('tsd-is-private') === -1
         && child.cssClasses.indexOf('tsd-is-not-exported') === -1).length > 0


### PR DESCRIPTION
This one liner change allows the update to TypeScript v3.7.4 on twilio-client.js, with the purpose to export type declarations.
[This is the specific error](https://github.com/twilio/twilio-client.js/pull/109#issuecomment-572790868) that this change aims to solve.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [*] I acknowledge that all my contributions will be made under the project's license.
